### PR TITLE
fix(projects): align action buttons to bottom of card

### DIFF
--- a/src/components/ProjectThumbnail.vue
+++ b/src/components/ProjectThumbnail.vue
@@ -29,7 +29,7 @@ function getTranslation(key: TranslationProp): string {
     <div class="flex flex-col gap-2 px-4 py-3 flex-1">
       <strong>{{ getTranslation("title") }}</strong>
       <p class="flex-1 text-sm">{{ getTranslation("description") }}</p>
-      <p class="flex gap-2 text-sm">
+      <p class="flex gap-2 text-sm mt-auto">
         <a
           v-if="project.data.live"
           class="text-accent-100 bg-accent-800 py-1 px-3 rounded"


### PR DESCRIPTION
## Summary

- Add `mt-auto` to the buttons `<p>` in `ProjectThumbnail.vue` so Site/Code buttons always sit at the bottom of each card regardless of description length

## Test plan

- [ ] Cards with short and long descriptions all have buttons aligned to the bottom

🤖 Generated with [Claude Code](https://claude.com/claude-code)